### PR TITLE
Register topnode component

### DIFF
--- a/topnode/CMakeLists.txt
+++ b/topnode/CMakeLists.txt
@@ -20,6 +20,10 @@ add_executable(resource_monitor src/topnode.cpp)
 target_link_libraries(resource_monitor resource_monitor_node)
 ament_target_dependencies(resource_monitor rclcpp)
 
+rclcpp_components_register_nodes(resource_monitor_node
+  "ResourceMonitorNode"
+)
+
 install(TARGETS
   resource_monitor_node
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
Needs to be exported so that the ament_index and command line tooling can find it.

Signed-off-by: Michael Carroll <michael@openrobotics.org>